### PR TITLE
fix: parse XDR Result to JSON

### DIFF
--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_type/src/lib.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_type/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contracterror, contractimpl, contracttype, vec, Address, Bytes, BytesN, Env, Map, Set, String,
-    Symbol, Vec, I256, U256,
+    contracterror, contractimpl, contracttype, vec, Address, Bytes, BytesN, Env, Map, RawVal, Set,
+    String, Symbol, Vec, I256, U256,
 };
 
 pub struct Contract;
@@ -54,6 +54,14 @@ pub enum Error {
 impl Contract {
     pub fn hello(_env: Env, hello: Symbol) -> Symbol {
         hello
+    }
+
+    pub fn void(_env: Env) {
+        // do nothing
+    }
+
+    pub fn raw_val(_env: Env) -> RawVal {
+        RawVal::default()
     }
 
     pub fn u32_fail_on_even(_env: Env, u32_: u32) -> Result<u32, Error> {

--- a/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_type/src/lib.rs
+++ b/cmd/crates/soroban-test/tests/fixtures/test-wasms/custom_type/src/lib.rs
@@ -1,7 +1,7 @@
 #![no_std]
 use soroban_sdk::{
-    contractimpl, contracttype, vec, Address, Bytes, BytesN, Env, Map, Set, String, Symbol, Vec,
-    I256, U256,
+    contracterror, contractimpl, contracttype, vec, Address, Bytes, BytesN, Env, Map, Set, String,
+    Symbol, Vec, I256, U256,
 };
 
 pub struct Contract;
@@ -43,10 +43,25 @@ pub enum ComplexEnum {
     Void,
 }
 
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[repr(u32)]
+pub enum Error {
+    OhNo = 1,
+}
+
 #[contractimpl]
 impl Contract {
     pub fn hello(_env: Env, hello: Symbol) -> Symbol {
         hello
+    }
+
+    pub fn u32_fail_on_even(_env: Env, u32_: u32) -> Result<u32, Error> {
+        if u32_ % 2 == 1 {
+            Ok(u32_)
+        } else {
+            Err(Error::OhNo)
+        }
     }
 
     pub fn u32_(_env: Env, u32_: u32) -> u32 {

--- a/cmd/crates/soroban-test/tests/it/custom_types.rs
+++ b/cmd/crates/soroban-test/tests/it/custom_types.rs
@@ -195,6 +195,24 @@ fn number_arg_return_err() {
 }
 
 #[test]
+fn void() {
+    invoke(&TestEnv::default(), "void")
+        .assert()
+        .success()
+        .stdout("\n")
+        .stderr("");
+}
+
+#[test]
+fn raw_val() {
+    invoke(&TestEnv::default(), "raw_val")
+        .assert()
+        .success()
+        .stdout("null\n")
+        .stderr("");
+}
+
+#[test]
 fn i32() {
     invoke_with_roundtrip("i32_", 42);
 }

--- a/cmd/crates/soroban-test/tests/it/custom_types.rs
+++ b/cmd/crates/soroban-test/tests/it/custom_types.rs
@@ -175,6 +175,26 @@ fn number_arg() {
 }
 
 #[test]
+fn number_arg_return_ok() {
+    invoke(&TestEnv::default(), "u32_fail_on_even")
+        .arg("--u32_")
+        .arg("1")
+        .assert()
+        .success()
+        .stdout("1\n");
+}
+
+#[test]
+fn number_arg_return_err() {
+    invoke(&TestEnv::default(), "u32_fail_on_even")
+        .arg("--u32_")
+        .arg("2")
+        .assert()
+        .success()
+        .stderr(predicates::str::contains("Status(ContractError(1))"));
+}
+
+#[test]
 fn i32() {
     invoke_with_roundtrip("i32_", 42);
 }

--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -438,7 +438,8 @@ impl Spec {
     /// May panic
     pub fn xdr_to_json(&self, val: &ScVal, output: &ScType) -> Result<Value, Error> {
         Ok(match (val, output) {
-            (ScVal::Map(None) | ScVal::Vec(None), ScType::Option(_)) => Value::Null,
+            (ScVal::Void, ScType::Val)
+            | (ScVal::Map(None) | ScVal::Vec(None), ScType::Option(_)) => Value::Null,
             (ScVal::Bool(_), ScType::Bool)
             | (ScVal::Void, ScType::Void)
             | (ScVal::String(_), ScType::String)

--- a/cmd/soroban-cli/src/strval.rs
+++ b/cmd/soroban-cli/src/strval.rs
@@ -650,6 +650,11 @@ impl Spec {
 
             (ScVal::Address(v), ScType::Address) => sc_address_to_json(v),
 
+            (ok_val, ScType::Result(result_type)) => {
+                let ScSpecTypeResult { ok_type, .. } = result_type.as_ref();
+                self.xdr_to_json(ok_val, ok_type)?
+            }
+
             (x, y) => return Err(Error::InvalidPair(x.clone(), y.clone())),
         })
     }


### PR DESCRIPTION
### What

The test here copies the logic of [the errors
example](https://github.com/stellar/soroban-examples/blob/main/errors/src/lib.rs),
showing that valid `Ok` results were not being correctly parsed to JSON.

### Why

The CLI is not correctly returning valid contract responses, if those
responses are wrapped in Result types

### Known limitations

N/A