### PR TITLE
Add long list for identity

### DIFF
--- a/cmd/soroban-cli/src/commands/config/locator.rs
+++ b/cmd/soroban-cli/src/commands/config/locator.rs
@@ -152,6 +152,20 @@ impl Args {
             .collect())
     }
 
+    pub fn list_identities_long(&self) -> Result<Vec<(String, String)>, Error> {
+        Ok(KeyType::Identity
+            .list_paths(&self.local_and_global()?)
+            .into_iter()
+            .flatten()
+            .map(|(name, location)| {
+                let path = match location {
+                    Location::Local(path) | Location::Global(path) => path,
+                };
+                (name, format!("{}", path.display()))
+            })
+            .collect())
+    }
+
     pub fn list_networks(&self) -> Result<Vec<String>, Error> {
         Ok(KeyType::Network
             .list_paths(&self.local_and_global()?)

--- a/cmd/soroban-cli/src/commands/identity/ls.rs
+++ b/cmd/soroban-cli/src/commands/identity/ls.rs
@@ -13,11 +13,28 @@ pub enum Error {
 pub struct Cmd {
     #[command(flatten)]
     pub config_locator: locator::Args,
+
+    #[arg(long, short = 'l')]
+    pub long: bool,
 }
 
 impl Cmd {
     pub fn run(&self) -> Result<(), Error> {
-        println!("{}", self.config_locator.list_identities()?.join("\n"));
+        let res = if self.long { self.ls_l() } else { self.ls() }?.join("\n");
+        println!("{res}");
         Ok(())
+    }
+
+    pub fn ls(&self) -> Result<Vec<String>, Error> {
+        Ok(self.config_locator.list_identities()?)
+    }
+
+    pub fn ls_l(&self) -> Result<Vec<String>, Error> {
+        Ok(self
+            .config_locator
+            .list_identities_long()?
+            .into_iter()
+            .map(|(name, location)| format!("{location}\nName: {name}\n"))
+            .collect::<Vec<String>>())
     }
 }

--- a/docs/soroban-cli-full-docs.md
+++ b/docs/soroban-cli-full-docs.md
@@ -634,6 +634,7 @@ List identities
 
 * `--global` — Use global config
 * `--config-dir <CONFIG_DIR>`
+* `-l`, `--long`
 
 
 


### PR DESCRIPTION
### What
Adding a `--long` flag to `soroban identity ls`, similar to `soroban network ls --long` to print out the paths to identity configuration files.

### Why
This was originally added in a previous PR (https://github.com/stellar/soroban-tools/pull/743) and was removed at some point - presumably unintentionally. This seems like a helpful addition to help users understand where their identities are being configured.

Example output:

```
$ soroban identity ls -l
/Users/elizabethengelman/.config/soroban/identity/alice.toml
Name: alice

/Users/elizabethengelman/.config/soroban/identity/bob.toml
Name: bob

/Users/elizabethengelman/.config/soroban/identity/carol.toml
Name: carol
```

Known limitations
N/A